### PR TITLE
Rework handling of authorization request state management.

### DIFF
--- a/credenza/api/oidc_client.py
+++ b/credenza/api/oidc_client.py
@@ -107,14 +107,15 @@ class OIDCClient:
                 key = k.as_dict()
                 logger.debug(f"Loaded JWK kid={key.get('kid')}, alg={key.get('alg')}")
 
-    def create_authorization_url(self, use_pkce, is_device=False, **kwargs):
+    def create_authorization_url(self, use_pkce, request_offline_access_scope=False, **kwargs):
         """
         Builds the /authorize URL.  If use_pkce=True, Authlib will
         auto-generate a code_verifier & code_challenge.
         Returns (url, state, code_verifier).
         """
         extra = kwargs or {}
-        scope = self.scope + " offline_access" if is_device and "offline_access" not in self.scope else None
+        scope = self.scope + " offline_access" \
+            if request_offline_access_scope and "offline_access" not in self.scope else None
         session = self.get_oauth_session(
             code_challenge_method='S256' if use_pkce else None,
             scope=scope

--- a/credenza/app.py
+++ b/credenza/app.py
@@ -112,13 +112,13 @@ def load_config(app):
             app.config["TRUSTED_ISSUERS"] = json.load(f)
 
     # create session augmentation provider map
-    provider_map = \
-        {"default":
-             import_string("credenza.api.session.augmentation.base_provider:DefaultSessionAugmentationProvider")()}
+    provider_map = {}
+    default_provider = "credenza.api.session.augmentation.base_provider:DefaultSessionAugmentationProvider"
     for realm, prof in app.config["OIDC_IDP_PROFILES"].items():
         cls_path = prof.get("session_augmentation_provider")
-        if cls_path:
-            provider_map[realm] = import_string(cls_path)()
+        if not cls_path:
+            cls_path = default_provider
+        provider_map[realm] = import_string(cls_path)()
     app.config["SESSION_AUGMENTATION_PROVIDERS"] = provider_map
 
 def init_logging(app):

--- a/credenza/refresh/refresh_worker.py
+++ b/credenza/refresh/refresh_worker.py
@@ -62,11 +62,11 @@ def run_refresh_worker(app):
 
             # Refresh access tokens for sessions with automatic refresh allowed
             if session.refresh_token and allow_auto_refresh:
-                modified = refresh_access_token(sid, session)
+                modified = bool(refresh_access_token(sid, session)) or modified
 
             # Refresh other tokens if needed and allowed
             if allow_auto_refresh:
-                modified = refresh_additional_tokens(sid, session)
+                modified = bool(refresh_additional_tokens(sid, session)) or modified
 
             # Just bump session TTL if allowed and it is about to expire and hasn't otherwise been modified
             if not modified and allow_auto_refresh:

--- a/credenza/rest/login_flow.py
+++ b/credenza/rest/login_flow.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import json
-import base64
 import logging
+import time
+import uuid
 from urllib.parse import urlencode, quote
 from flask import Blueprint, request, redirect, current_app, make_response, abort, jsonify, g
+from ..api.session.storage.session_store import TRANSIENT_DATA_TTL
 from ..api.util import has_current_session, get_effective_scopes, generate_nonce, augment_session, get_cookie_domain, \
-    revoke_tokens
+    revoke_tokens, safe_referrer, is_transient_request_error
 from ..telemetry import audit_event
 
 logger = logging.getLogger(__name__)
@@ -34,22 +35,21 @@ def login():
     realm = current_app.config["DEFAULT_REALM"]
     client = factory.get_client(realm)
 
-    referrer = request.args.get('referrer', current_app.config.get("POST_LOGIN_REDIRECT", "/"))
+    try:
+        client = factory.get_client(realm)
+    except Exception as e:
+        abort(502, description=f"OIDC client init failed: {e}")
+
+    referrer = safe_referrer(request.args.get('referrer')) or current_app.config.get("POST_LOGIN_REDIRECT", "/")
     logger.debug("Login referrer: %s", referrer)
 
     sid = has_current_session()
     if sid is not None:
         return redirect(referrer)
 
-    state = {
-        "nonce": generate_nonce(),
-        "referrer": referrer
-    }
-    state = base64.urlsafe_b64encode(json.dumps(state).encode()).decode()
+    state = uuid.uuid4().hex
     nonce = generate_nonce()
     redirect_uri = f"{current_app.config['BASE_URL']}/callback"
-
-    store.store_nonce(state, nonce)
 
     auth_url, auth_state, code_verifier = client.create_authorization_url(
         use_pkce=current_app.config.get("ENABLE_PKCE", True),
@@ -58,96 +58,138 @@ def login():
         nonce=nonce,
         redirect_uri=redirect_uri
     )
-    if code_verifier is not None:
-        store.store_pkce_verifier(auth_state, code_verifier)
+
+    authn_request_ctx = {
+        "nonce": nonce,
+        "code_verifier": code_verifier,
+        "scope": client.scope,
+        "realm": realm,
+        "referrer": referrer,
+        "redirect_uri": redirect_uri,
+        "created_at": int(time.time()),
+    }
+    store.store_authn_request_ctx(state, authn_request_ctx, ttl=TRANSIENT_DATA_TTL)
 
     return redirect(auth_url)
 
 @login_blueprint.route("/callback")
 def callback():
+    err = request.args.get("error")
+    if err:
+        desc = request.args.get("error_description") or err
+        abort(400, description=f"Authorization error: {desc}")
+
     code = request.args.get("code")
     state = request.args.get("state")
-    logger.debug("callback state: %s", state)
     if not code or not state:
-        abort(400, description="Missing code or state")
+        abort(400, description="Callback is missing code or state")
 
     store = current_app.config["SESSION_STORE"]
     factory = current_app.config["OIDC_CLIENT_FACTORY"]
-    realm = current_app.config["DEFAULT_REALM"]
-    client = factory.get_client(realm)
     metadata = {}
 
-    redirect_uri = f"{current_app.config['BASE_URL']}/callback"
-    code_verifier = store.get_pkce_verifier(state)
-    if current_app.config.get("ENABLE_PKCE", True) and not code_verifier:
-        abort(400, "Missing PKCE verifier")
-    tokens = client.exchange_code_for_tokens(code, redirect_uri, code_verifier)
-    store.delete_pkce_verifier(state)
-    scopes_granted = tokens.get('scope', [])
+    authn_request_ctx = store.get_authn_request_ctx(state)
+    if not authn_request_ctx:
+        abort(400, description=f"Missing or expired request context for state: {state}")
 
-    # for now, do not support refresh tokens in non-device logins, even if the IDP (e.g. Keycloak) returns them
-    if "refresh_token" in tokens:
-        tokens["refresh_token"] = None
-
-    # Validate nonce and token claims
-    nonce = store.get_nonce(state)
-    if not nonce:
-        abort(400, description="Missing or expired nonce")
+    realm = authn_request_ctx.get("realm")
     try:
-        userinfo = client.validate_id_token(tokens["id_token"], nonce)
+        client = factory.get_client(realm)
     except Exception as e:
-        abort(400, description=f"Unable to validate id_token: {e}")
-    finally:
-        store.delete_nonce(state)
+        abort(502, description=f"OIDC client init failed: {e}")
 
-    # Augment the session, if applicable
-    userinfo, additional_tokens = augment_session(tokens, realm, userinfo, metadata)
+    preserve_ctx = False
+    try:
+        now = int(time.time())
+        if now - int(authn_request_ctx.get("created_at", 0)) > TRANSIENT_DATA_TTL:
+            abort(400, description="State expired")
 
-    sid = store.generate_session_id()
-    session_key, session_data = store.create_session(
-        session_id=sid,
-        id_token=tokens.get("id_token"),
-        access_token=tokens.get("access_token"),
-        refresh_token=tokens.get("refresh_token"),
-        scopes=scopes_granted,
-        userinfo=userinfo,
-        realm=realm,
-        metadata=metadata,
-        additional_tokens=additional_tokens
-    )
+        code_verifier =authn_request_ctx.get("code_verifier")
+        if current_app.config.get("ENABLE_PKCE", True) and not code_verifier:
+            abort(400, "Missing PKCE verifier")
 
-    sub = userinfo.get("sub")
-    user = userinfo.get("email")
-    audit_event("login",
-                session_id=sid,
-                user=user,
-                sub=sub,
-                scopes=get_effective_scopes(session_data),
-                realm=realm)
-    logger.info(f"Login successful for user {user} ({sub}) with session id {sid} on realm {realm}")
+        try:
+            redirect_uri = authn_request_ctx.get("redirect_uri")
+            tokens = client.exchange_code_for_tokens(code, redirect_uri, code_verifier)
+        except Exception as e:
+            if is_transient_request_error(e):
+                preserve_ctx = True
+                # keep context briefly so user can retry
+                age = now - int(authn_request_ctx.get("created_at", 0))
+                remaining = max(0, TRANSIENT_DATA_TTL - age)
+                if remaining == 0:
+                    abort(400, description="State expired")
+                store.store_authn_request_ctx(state, authn_request_ctx, ttl=min(60, remaining))
+                abort(502, description=f"Token exchange failed (temporary): {e}")
+            abort(400, description=f"Token exchange failed: {e}")  # non-transient -> delete in finally
 
-    if metadata.get("augmentation_deferred", False):
-        g.session_key = session_key
+        scopes_granted = tokens.get('scope', authn_request_ctx.get("scope"))
+
+        # for now, do not support refresh tokens in non-device logins, even if the IDP (e.g. Keycloak) returns them
+        if "refresh_token" in tokens:
+            tokens["refresh_token"] = None
+
+        # Validate nonce and token claims
+        nonce = authn_request_ctx.get("nonce")
+        if not nonce:
+            abort(400, description="Missing or expired nonce")
+        try:
+            userinfo = client.validate_id_token(tokens["id_token"], nonce)
+        except Exception as e:
+            abort(400, description=f"Unable to validate id_token: {e}")
+
+        # Augment the session, if applicable
         userinfo, additional_tokens = augment_session(tokens, realm, userinfo, metadata)
-        metadata.pop("augmentation_deferred", None)
-        session_data.userinfo = userinfo
-        session_data.metadata = metadata
-        session_data.additional_tokens = additional_tokens
-        store.update_session(sid, session_data)
 
-    decoded_state = json.loads(base64.urlsafe_b64decode(state).decode())
-    referrer = decoded_state.get("referrer", current_app.config.get("POST_LOGIN_REDIRECT", "/"))
-    logger.debug(f"Callback referrer: {referrer}")
+        sid = store.generate_session_id()
+        session_key, session_data = store.create_session(
+            session_id=sid,
+            id_token=tokens.get("id_token"),
+            access_token=tokens.get("access_token"),
+            refresh_token=tokens.get("refresh_token"),
+            scopes=scopes_granted,
+            userinfo=userinfo,
+            realm=realm,
+            metadata=metadata,
+            additional_tokens=additional_tokens
+        )
 
-    response = redirect(referrer)
-    response.set_cookie(current_app.config["COOKIE_NAME"],
-                        session_key,
-                        domain=get_cookie_domain(),
-                        httponly=True,
-                        secure=True,
-                        samesite="Lax")
+        sub = userinfo.get("sub")
+        user = userinfo.get("email")
+        audit_event("login",
+                    session_id=sid,
+                    user=user,
+                    sub=sub,
+                    scopes=get_effective_scopes(session_data),
+                    realm=realm)
+        logger.info(f"Login successful for user {user} ({sub}) with session id {sid} on realm {realm}")
 
-    return response
+        if metadata.get("augmentation_deferred", False):
+            g.session_key = session_key
+            userinfo, additional_tokens = augment_session(tokens, realm, userinfo, metadata)
+            metadata.pop("augmentation_deferred", None)
+            session_data.userinfo = userinfo
+            session_data.metadata = metadata
+            session_data.additional_tokens = additional_tokens
+            store.update_session(sid, session_data)
+
+        referrer = authn_request_ctx.get("referrer", current_app.config.get("POST_LOGIN_REDIRECT", "/"))
+        logger.debug(f"Callback referrer: {referrer}")
+        response = redirect(referrer)
+        response.set_cookie(current_app.config["COOKIE_NAME"],
+                            session_key,
+                            domain=get_cookie_domain(),
+                            httponly=True,
+                            secure=True,
+                            samesite="Lax")
+        return response
+
+    finally:
+        if not preserve_ctx:
+            try:
+                store.delete_authn_request_ctx(state)
+            except Exception:
+                logger.exception(f"Failed to delete authn_request_ctx for state {state}")
 
 @login_blueprint.route("/logout", methods=["GET"])
 def logout():
@@ -188,7 +230,13 @@ def logout():
         resp = make_response({"logout_url": redirect_uri})
     else:
         resp = make_response(redirect(redirect_uri))
-    resp.set_cookie(current_app.config["COOKIE_NAME"], "", expires=0)
+
+    resp.set_cookie(
+        current_app.config["COOKIE_NAME"], "",
+        expires=0,
+        domain=get_cookie_domain(),
+        secure=True, httponly=True, samesite="Lax"
+    )
     return resp
 
 # This is a webauthn2 legacy compatibility endpoint
@@ -198,7 +246,7 @@ def preauth():
     referrer_arg = request.args.get('referrer')
     referer_header = request.environ.get('HTTP_REFERER')
     post_login_redirect = current_app.config.get("POST_LOGIN_REDIRECT", "/")
-    referrer = referrer_arg or referer_header or post_login_redirect
+    referrer = safe_referrer(referrer_arg or referer_header or post_login_redirect) or "/"
     redirect_url = f"{current_app.config['BASE_URL']}/login?referrer={quote(referrer, safe='')}"
 
     if do_redirect:

--- a/test/api/test_session_store.py
+++ b/test/api/test_session_store.py
@@ -141,10 +141,10 @@ def test_list_session_ids_and_get_ttl(frozen_time, store):
 
 def test_nonce_lifecycle(store):
     # store_nonce and get_nonce should round-trip the JSON-able object
-    store.store_nonce("n1", "abc123")
-    assert store.get_nonce("n1") == "abc123"
-    store.delete_nonce("n1")
-    assert store.get_nonce("n1") is None
+    store.store_authn_request_ctx("n1", {"nonce":"abc123"})
+    assert store.get_authn_request_ctx("n1") == {"nonce":"abc123"}
+    store.delete_authn_request_ctx("n1")
+    assert store.get_authn_request_ctx("n1") is None
 
 def test_device_flow_mappings(store):
     store.set_device_flow("dev1", "abc123", store.ttl)

--- a/test/refresh/test_refresh_worker.py
+++ b/test/refresh/test_refresh_worker.py
@@ -55,7 +55,7 @@ def client_stub():
 @pytest.fixture
 def factory(client_stub):
     class Factory:
-        def get_client(self, realm):
+        def get_client(self, realm, **kwargs):
             return client_stub
     return Factory()
 
@@ -167,7 +167,7 @@ def test_additional_token_refresh_success_and_failure(app,
             else:
                 pytest.skip(f"Unexpected refresh_token {refresh_token}")
 
-    monkeypatch.setattr(factory, "get_client", lambda realm: DummyClient(now))
+    monkeypatch.setattr(factory, "get_client", lambda realm, **kwargs: DummyClient(now))
 
     # Run the worker: only "good" and "fail" are under threshold=500
     with app.app_context():
@@ -310,7 +310,7 @@ def test_device_access_token_refresh(app,
                 "refresh_expires_at": self.now + 7200,
             }
 
-    monkeypatch.setattr(factory,"get_client",lambda realm: DummyClient(now))
+    monkeypatch.setattr(factory, "get_client", lambda realm, **kwargs: DummyClient(now))
 
     # run once
     with app.app_context():


### PR DESCRIPTION
Introduce `authn_request_ctx` to store auth request context variables on server-side during login flow lifecycle. Removed specialized storage layer methods for `nonce` and PKCE `code_verifier` as they are now part of `authn_request_ctx`. Similar change in device flow where these variables are now persisted in the `flow` state. Removed storage of `referrer` in `state` and added it to `authn_request_ctx`.

Numerous bugfixes, particularly with refresh worker and token refreshing for device sessions.
Improved exception handling UX for upstream requests to IDP. 
Updated unit tests.